### PR TITLE
add original death source to death messages

### DIFF
--- a/src/main/java/com/cartoonishvillain/incapacitated/capability/IPlayerCapability.java
+++ b/src/main/java/com/cartoonishvillain/incapacitated/capability/IPlayerCapability.java
@@ -1,5 +1,7 @@
 package com.cartoonishvillain.incapacitated.capability;
 
+import net.minecraft.world.damagesource.DamageSource;
+
 public interface IPlayerCapability {
     boolean getIsIncapacitated();
     void setIsIncapacitated(boolean isIncapacitated);
@@ -18,4 +20,6 @@ public interface IPlayerCapability {
     int getJumpDelay();
     void setJumpDelay(int delay);
     void countDelay();
+    DamageSource getSourceOfDeath();
+    void setSourceOfDeath(DamageSource causeOfDeath);
 }

--- a/src/main/java/com/cartoonishvillain/incapacitated/capability/PlayerCapabilityManager.java
+++ b/src/main/java/com/cartoonishvillain/incapacitated/capability/PlayerCapabilityManager.java
@@ -1,7 +1,10 @@
 package com.cartoonishvillain.incapacitated.capability;
 
 import com.cartoonishvillain.incapacitated.Incapacitated;
+import com.cartoonishvillain.incapacitated.events.BleedOutDamage;
+
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -19,6 +22,8 @@ public class PlayerCapabilityManager implements IPlayerCapability, ICapabilityPr
     protected int reviveCounter = Incapacitated.config.REVIVETICKS.get();
     protected int jumpDelay = 0;
     public final LazyOptional<IPlayerCapability> holder = LazyOptional.of(()->this);
+    private DamageSource originalSource;
+    
     @Override
     public boolean getIsIncapacitated() {
         return incapacitated;
@@ -108,6 +113,17 @@ public class PlayerCapabilityManager implements IPlayerCapability, ICapabilityPr
         else if(jumpDelay < 0) jumpDelay = 0;
     }
 
+    @Override
+    public DamageSource getSourceOfDeath() {
+        return originalSource != null
+                ? originalSource
+                : new BleedOutDamage(DamageSource.OUT_OF_WORLD);
+    }
+    
+    @Override
+    public void setSourceOfDeath(DamageSource causeOfDeath) {
+        originalSource = new BleedOutDamage(causeOfDeath);        
+    }
 
     @Nonnull
     @Override
@@ -133,4 +149,5 @@ public class PlayerCapabilityManager implements IPlayerCapability, ICapabilityPr
         downsUntilDeath = tag.getInt("incapCounter");
         giveUpJumps = tag.getInt("jumpCounter");
     }
+
 }

--- a/src/main/java/com/cartoonishvillain/incapacitated/capability/PlayerCapabilityManager.java
+++ b/src/main/java/com/cartoonishvillain/incapacitated/capability/PlayerCapabilityManager.java
@@ -116,8 +116,8 @@ public class PlayerCapabilityManager implements IPlayerCapability, ICapabilityPr
     @Override
     public DamageSource getSourceOfDeath() {
         return originalSource != null
-                ? originalSource
-                : new BleedOutDamage(DamageSource.OUT_OF_WORLD);
+                ? originalSource.bypassArmor()
+                : new BleedOutDamage(DamageSource.OUT_OF_WORLD).bypassArmor();
     }
     
     @Override

--- a/src/main/java/com/cartoonishvillain/incapacitated/events/BleedOutDamage.java
+++ b/src/main/java/com/cartoonishvillain/incapacitated/events/BleedOutDamage.java
@@ -1,14 +1,20 @@
 package com.cartoonishvillain.incapacitated.events;
 
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.damagesource.EntityDamageSource;
-import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 
-public class BleedOutDamage extends DamageSource {
-    public BleedOutDamage(String p_i1566_1_) {
-        super(p_i1566_1_);
+public class BleedOutDamage extends DamageSource{
+    private final DamageSource originalSource;
+    public BleedOutDamage(DamageSource originalKillMethod) {
+        super("bleedout");
+        originalSource = originalKillMethod;
     }
-    public static DamageSource playerOutOfTime(Entity entity){
-        return new EntityDamageSource("bleedout", entity).bypassArmor();
+    
+    @Override
+    public Component getLocalizedDeathMessage(LivingEntity player) {
+        Component originalDeathMsg = originalSource.getLocalizedDeathMessage(player);
+        return new TranslatableComponent("death.attack." + this.msgId, originalDeathMsg);        
     }
 }

--- a/src/main/java/com/cartoonishvillain/incapacitated/events/ForgeEvents.java
+++ b/src/main/java/com/cartoonishvillain/incapacitated/events/ForgeEvents.java
@@ -12,14 +12,12 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.Items;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -28,7 +26,6 @@ import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -60,6 +57,7 @@ public class ForgeEvents {
                     //if downs until death is 0 or higher, we can cancel the death event because the user is down.
                     if (h.getDownsUntilDeath() > -1) {
                         h.setIsIncapacitated(true);
+                        h.setSourceOfDeath(event.getSource());
                         event.setCanceled(true);
                         player.setHealth(player.getMaxHealth());
                         if(Incapacitated.config.GLOWING.get())
@@ -167,7 +165,7 @@ public class ForgeEvents {
                             }
                         } else {
                             if (h.countTicksUntilDeath()) {
-                                event.player.hurt(BleedOutDamage.playerOutOfTime(event.player), event.player.getMaxHealth() * 10);
+                                event.player.hurt(h.getSourceOfDeath(), event.player.getMaxHealth() * 10);
                                 event.player.setForcedPose(null);
                                 h.setReviveCount(Incapacitated.config.REVIVETICKS.get());
                                 h.resetGiveUpJumps();
@@ -196,7 +194,7 @@ public class ForgeEvents {
             player.getCapability(PlayerCapability.INSTANCE).ifPresent(h ->{
                 if(h.getIsIncapacitated() && h.getJumpDelay() == 0){
                     if(h.giveUpJumpCount()){
-                        player.hurt(BleedOutDamage.playerOutOfTime(player), player.getMaxHealth() * 10);
+                        player.hurt(h.getSourceOfDeath(), player.getMaxHealth() * 10);
                         player.setForcedPose(null);
                         h.setReviveCount(Incapacitated.config.DOWNCOUNT.get());
                         h.resetGiveUpJumps();

--- a/src/main/resources/assets/incapacitated/lang/en_us.json
+++ b/src/main/resources/assets/incapacitated/lang/en_us.json
@@ -1,3 +1,3 @@
 {
-  "death.attack.bleedout": "%1$s bled out"
+  "death.attack.bleedout": "%1$s and bled out"
 }


### PR DESCRIPTION
The changes in this PR wrap the original cause of death in the `BleedOutDamage` for use in the give up and timeout `hurt` calls.

## Player Capability Changes
- Added a `DamageSource` variable which can be set/got as applicable
- `originalSource` getter and setter methods wrap any supplied `DamageSource` into a `BleedOutDamage`.
- `originalSource` is not serialized on save, and if a player logs out while incapacitated, when they die after relog, a generic `OUT_OF_WORLD` source is supplied

## EventHandler Changes
- on death, provide the original damage source to the player cap
- on failure to revive, when calling `hurt` use the damage source stored in the cap

## Lang changes
- added " and " to message to make more linguistic sense

# Testing
- Tested standard timeout death
- Tested give up death
- Tested logging out while incapacitated and relogging (both give up and time out cases)

## Example messages
![image](https://user-images.githubusercontent.com/62700786/188978197-ecfc8c6e-6206-406d-81c5-c6f0e973d769.png)
![image](https://user-images.githubusercontent.com/62700786/188978218-d824d499-8898-4e62-9082-87e81ed3281d.png)

